### PR TITLE
Changed bind target for click

### DIFF
--- a/source/frontend/base/default/js/partials/_addToCart.js
+++ b/source/frontend/base/default/js/partials/_addToCart.js
@@ -14,7 +14,7 @@ AligentAjaxAddToCartEnabler = Class.create({
     },
 
     bindEvents: function() {
-        Event.on(this.container, 'click', this.selector, this.onSubmit.bind(this));
+        this.container.select(this.selector).invoke('observe', 'click', this.onSubmit.bind(this));
     },
 
     onSubmit: function(ev, dummy, overrideForm) {


### PR DESCRIPTION
This changes the click bind event from the container to the selector. This allows it to properly read the disabled property of the selector.
Fixes issue where onSubmit being called when the add to cart button is disabled.
